### PR TITLE
naturalistic-stim updates

### DIFF
--- a/quail/__init__.py
+++ b/quail/__init__.py
@@ -1,4 +1,4 @@
-from .load import load, load_example_data, load_egg
+from .load import load, load_example_data, load_egg, loadEL
 from .egg import Egg, FriedEgg
 from .analysis.analysis import analyze
 from .plot import plot

--- a/quail/analysis/recmat.py
+++ b/quail/analysis/recmat.py
@@ -63,30 +63,58 @@ def _feature_filter(presented, recalled, feature):
     recalled = recalled.applymap(lambda x: x[feature] if x['item'] is not np.nan else np.nan)
     return presented, recalled
 
+# def _recmat(presented, recalled, match, distance, whiten=False):
+#     if match in ('exact', 'best'):
+#         result = np.empty(presented.shape)*np.nan
+#     else:
+#         result = np.empty(tuple(list(presented.shape)+[recalled.shape[1]]))*np.nan
+#
+#     for i, idx in enumerate(presented.index.get_values()):
+#         p = np.stack(presented.loc[idx].get_values())
+#         r = np.stack(recalled.loc[idx].dropna().get_values())
+#         if match is 'exact':
+#             m = [np.where(x==p)[0] for x in r]
+#             print(m)
+#             result[idx, :] = [x[0]+1 if len(x)>0 else np.nan for x in m]
+#         elif match is 'best':
+#             res = np.empty(p.shape[0])*np.nan
+#             tmp = 1 - cdist(r, p, distance)
+#             if whiten:
+#                 tmp = _whiten(p, tmp)
+#             tmp = np.array(np.argmax(tmp, 1)+1).astype(np.float64)
+#             res[:r.shape[0]]=tmp
+#             result[i, :] = res
+#         elif match is 'smooth':
+#             tmp = 1 - cdist(r, p, distance)
+#             if whiten:
+#                 tmp = _whiten(p, tmp)
+#             result[i, :, :tmp.shape[0]] = tmp.T
+#     return result
+
 def _recmat(presented, recalled, match, distance, whiten=False):
     if match in ('exact', 'best'):
-        result = np.empty(presented.shape)*np.nan
+        cols = max(presented.shape[1], recalled.shape[1])
+        result = np.empty((presented.shape[0], cols))*np.nan
     else:
         result = np.empty(tuple(list(presented.shape)+[recalled.shape[1]]))*np.nan
 
     for i, idx in enumerate(presented.index.get_values()):
-        p = np.stack(presented.loc[idx].get_values())
-        r = np.stack(recalled.loc[idx].dropna().get_values())
+        p = presented.loc[idx].get_values()
+        r = recalled.loc[idx].dropna().get_values()
+        if (p.ndim==1 or r.ndim==1):
+            p = np.atleast_2d(p).T
+            r = np.atleast_2d(r).T
         if match is 'exact':
-            m = [np.where(x==p)[0] for x in r]
-            result[idx, :] = [x[0]+1 if len(x)>0 else np.nan for x in m]
+            m = [np.where((p==x).all(axis=1))[0] for x in r]
+            result[i, :len(m)] = [x[0]+1 if len(x)>0 else np.nan for x in m]
         elif match is 'best':
             res = np.empty(p.shape[0])*np.nan
             tmp = 1 - cdist(r, p, distance)
-            if whiten:
-                tmp = _whiten(p, tmp)
             tmp = np.array(np.argmax(tmp, 1)+1).astype(np.float64)
             res[:r.shape[0]]=tmp
             result[i, :] = res
         elif match is 'smooth':
             tmp = 1 - cdist(r, p, distance)
-            if whiten:
-                tmp = _whiten(p, tmp)
             result[i, :, :tmp.shape[0]] = tmp.T
     return result
 

--- a/quail/analysis/recmat.py
+++ b/quail/analysis/recmat.py
@@ -63,33 +63,6 @@ def _feature_filter(presented, recalled, feature):
     recalled = recalled.applymap(lambda x: x[feature] if x['item'] is not np.nan else np.nan)
     return presented, recalled
 
-# def _recmat(presented, recalled, match, distance, whiten=False):
-#     if match in ('exact', 'best'):
-#         result = np.empty(presented.shape)*np.nan
-#     else:
-#         result = np.empty(tuple(list(presented.shape)+[recalled.shape[1]]))*np.nan
-#
-#     for i, idx in enumerate(presented.index.get_values()):
-#         p = np.stack(presented.loc[idx].get_values())
-#         r = np.stack(recalled.loc[idx].dropna().get_values())
-#         if match is 'exact':
-#             m = [np.where(x==p)[0] for x in r]
-#             print(m)
-#             result[idx, :] = [x[0]+1 if len(x)>0 else np.nan for x in m]
-#         elif match is 'best':
-#             res = np.empty(p.shape[0])*np.nan
-#             tmp = 1 - cdist(r, p, distance)
-#             if whiten:
-#                 tmp = _whiten(p, tmp)
-#             tmp = np.array(np.argmax(tmp, 1)+1).astype(np.float64)
-#             res[:r.shape[0]]=tmp
-#             result[i, :] = res
-#         elif match is 'smooth':
-#             tmp = 1 - cdist(r, p, distance)
-#             if whiten:
-#                 tmp = _whiten(p, tmp)
-#             result[i, :, :tmp.shape[0]] = tmp.T
-#     return result
 
 def _recmat(presented, recalled, match, distance, whiten=False):
     if match in ('exact', 'best'):

--- a/quail/egg.py
+++ b/quail/egg.py
@@ -284,7 +284,8 @@ class Egg(object):
             'subjname' : self.subjname,
             'listgroup' : self.listgroup,
             'listname' : self.listname,
-            'date_created' : self.date_created
+            'date_created' : self.date_created,
+            'meta' : self.meta
         }
 
         # if extension wasn't included, add it
@@ -399,7 +400,8 @@ class FriedEgg(object):
             'n_lists' : self.n_lists,
             'n_subjects' : self.n_subjects,
             'position' : self.position,
-            'date_created' : self.date_created
+            'date_created' : self.date_created,
+            'meta' : self.meta
         }
 
         if fname[-4:]!='.fegg':

--- a/quail/load.py
+++ b/quail/load.py
@@ -471,7 +471,7 @@ def loadEL(dbpath=None, recpath=None, remove_subs=None, wordpool=None, groupby=N
 
     # convert utf-8 bytes type to string
     def update_types(egg):
-        featlist = list(egg.rec.loc[0].loc[0].values.tolist()[0].keys())
+        featlist = list(egg.pres.loc[0].loc[0].values.tolist()[0].keys())
         def update1df(df):
             for sub in range(egg.n_subjects):
                 for liszt in range(egg.n_lists):
@@ -486,24 +486,23 @@ def loadEL(dbpath=None, recpath=None, remove_subs=None, wordpool=None, groupby=N
         update1df(egg.pres)
         update1df(egg.rec)
 
-    def map_features(egg):
-        old_meta = egg.meta    # store metadata for new egg object
-        eggs = [egg]
+    for egg in eggs:
+        update_types(egg)
+        old_meta = egg.meta
+        temp_eggs = [egg]
 
         for i in range(egg.n_subjects):
             e = egg.crack(subjects=[i])
             stim = e.pres.values.ravel()
             stim_dict = {str(x['item']) : {k:v for k, v in iter(x.items())} for x in stim}
+
             e.rec = e.rec.applymap(lambda x: checkword(x))
-            eggs.append(e)
+            temp_eggs.append(e)
 
-        edited_egg = stack_eggs(eggs)
-        egg = edited_egg.crack(subjects=[i for i in range(egg.n_subjects,egg.n_subjects*2)])
-        egg.meta = old_meta
-
-    for egg in eggs:
-        update_types(egg)
-        map_features(egg)
+        edited_egg = stack_eggs(temp_eggs)
+        mapped_egg = edited_egg.crack(subjects=[i for i in range(egg.n_subjects,egg.n_subjects*2)])
+        mapped_egg.meta = old_meta
+        eggs[eggs.index(egg)] = mapped_egg
 
     if len(eggs)>1:
         return eggs

--- a/quail/load.py
+++ b/quail/load.py
@@ -215,7 +215,7 @@ def loadEL(dbpath=None, recpath=None, remove_subs=None, wordpool=None, groupby=N
         for line in data_frame.iterrows():
             try:
                 if json.loads(line[1]['responses'])['Q1'].lower() in ['kirsten','allison','allison\nallison','marisol','marisiol', 'maddy','campbell', 'campbell field', 'kirsten\nkirsten', 'emily', 'bryan', 'armando', 'armando ortiz', 'maddy/lucy',
-                                                                      'paxton', 'lucy']:
+                                                                      'paxton', 'lucy', 'campbell\ncampbell']:
                     delete = False
                 else:
                     delete = True

--- a/quail/load.py
+++ b/quail/load.py
@@ -215,8 +215,8 @@ def loadEL(dbpath=None, recpath=None, remove_subs=None, wordpool=None, groupby=N
         indexes=[]
         for line in data_frame.iterrows():
             try:
-                if json.loads(line[1]['responses'])['Q1'].lower() in ['kirsten','allison','allison\nallison','marisol', 'marisol ','marisiol', 'maddy','campbell', 'campbell field', 'kirsten\nkirsten', 'emily', 'bryan', 'armando', 'armando ortiz', 'maddy/lucy',
-                                                                      'paxton', 'lucy', 'campbell\ncampbell', 'madison', 'darya']:
+                if json.loads(line[1]['responses'])['Q1'].lower() in ['kirsten','allison','allison\nallison','marisol', 'marisol ','marisiol', 'maddy','campbell', 'campbell field', 'kirsten\nkirsten', 'emily', 'bryan', 'armando', 'armando ortiz',
+                                                                      'maddy/lucy','paxton', 'lucy','campbell\ncampbell','madison','darya','rachael']:
                     delete = False
                 else:
                     delete = True

--- a/quail/load.py
+++ b/quail/load.py
@@ -15,7 +15,6 @@ import pickle
 import os
 import deepdish as dd
 from .helpers import parse_egg, stack_eggs
-import traceback
 
 def load(filepath, update=True):
     """

--- a/quail/load.py
+++ b/quail/load.py
@@ -14,7 +14,7 @@ import dill
 import pickle
 import os
 import deepdish as dd
-from .helpers import parse_egg
+from .helpers import parse_egg, stack_eggs
 import traceback
 
 def load(filepath, update=True):
@@ -461,13 +461,13 @@ def loadEL(dbpath=None, recpath=None, remove_subs=None, wordpool=None, groupby=N
 
     # map feature dictionaries in pres df to rec df
     def checkword(x):
-    if x is None:
-        return x
-    else:
-        try:
-            return stim_dict[x['item']]
-        except:
+        if x is None:
             return x
+        else:
+            try:
+                return stim_dict[x['item']]
+            except:
+                return x
 
     # convert utf-8 bytes type to string
     def update_types(egg):
@@ -497,7 +497,7 @@ def loadEL(dbpath=None, recpath=None, remove_subs=None, wordpool=None, groupby=N
             e.rec = e.rec.applymap(lambda x: checkword(x))
             eggs.append(e)
 
-        edited_egg = quail.stack_eggs(eggs)
+        edited_egg = stack_eggs(eggs)
         egg = edited_egg.crack(subjects=[i for i in range(egg.n_subjects,egg.n_subjects*2)])
         egg.meta = old_meta
 

--- a/quail/load.py
+++ b/quail/load.py
@@ -15,6 +15,7 @@ import pickle
 import os
 import deepdish as dd
 from .helpers import parse_egg
+import traceback
 
 def load(filepath, update=True):
     """
@@ -311,11 +312,11 @@ def loadEL(dbpath=None, recpath=None, remove_subs=None, wordpool=None, groupby=N
         recalledWords = []
         for i in range(0,16):
             try:
-                f = open(recpath + subid + '/' + subid + '-' + str(i) + '.wav.txt', 'rb')
+                f = open(recpath + subid + '/' + subid + '-' + str(i) + '.wav.txt', 'r')
                 spamreader = csv.reader(f, delimiter=',', quotechar='|')
             except (IOError, OSError) as e:
                 try:
-                    f = open(recpath + subid + '-' + str(i) + '.wav.txt', 'rb')
+                    f = open(recpath + subid + '-' + str(i) + '.wav.txt', 'r')
                     spamreader = csv.reader(f, delimiter=',', quotechar='|')
                 except (IOError, OSError) as e:
                     print(e)

--- a/quail/load.py
+++ b/quail/load.py
@@ -215,7 +215,7 @@ def loadEL(dbpath=None, recpath=None, remove_subs=None, wordpool=None, groupby=N
         for line in data_frame.iterrows():
             try:
                 if json.loads(line[1]['responses'])['Q1'].lower() in ['kirsten','allison','allison\nallison','marisol', 'marisol ','marisiol', 'maddy','campbell', 'campbell field', 'kirsten\nkirsten', 'emily', 'bryan', 'armando', 'armando ortiz', 'maddy/lucy',
-                                                                      'paxton', 'lucy', 'campbell\ncampbell', 'madison']:
+                                                                      'paxton', 'lucy', 'campbell\ncampbell', 'madison', 'darya']:
                     delete = False
                 else:
                     delete = True

--- a/quail/load.py
+++ b/quail/load.py
@@ -214,8 +214,8 @@ def loadEL(dbpath=None, recpath=None, remove_subs=None, wordpool=None, groupby=N
         indexes=[]
         for line in data_frame.iterrows():
             try:
-                if json.loads(line[1]['responses'])['Q1'].lower() in ['kirsten','allison','allison\nallison','marisol','marisiol', 'maddy','campbell', 'campbell field', 'kirsten\nkirsten', 'emily', 'bryan', 'armando', 'armando ortiz', 'maddy/lucy',
-                                                                      'paxton', 'lucy', 'campbell\ncampbell']:
+                if json.loads(line[1]['responses'])['Q1'].lower() in ['kirsten','allison','allison\nallison','marisol', 'marisol ','marisiol', 'maddy','campbell', 'campbell field', 'kirsten\nkirsten', 'emily', 'bryan', 'armando', 'armando ortiz', 'maddy/lucy',
+                                                                      'paxton', 'lucy', 'campbell\ncampbell', 'madison']:
                     delete = False
                 else:
                     delete = True

--- a/quail/load.py
+++ b/quail/load.py
@@ -106,7 +106,13 @@ def load_egg(filepath, update=True):
             egg = pickle.load(f)
 
     if update:
-        return egg.crack()
+        if egg.meta:
+            old_meta = egg.meta
+            egg.crack()
+            egg.meta = old_meta
+            return egg
+        else:
+            return egg.crack()
     else:
         return egg
 

--- a/quail/load.py
+++ b/quail/load.py
@@ -214,7 +214,7 @@ def loadEL(dbpath=None, recpath=None, remove_subs=None, wordpool=None, groupby=N
         indexes=[]
         for line in data_frame.iterrows():
             try:
-                if json.loads(line[1]['responses'])['Q1'].lower() in ['kirsten','allison','marisol','marisiol', 'maddy','campbell', 'campbell field', 'kirsten\\nkirsten', 'emily', 'bryan', 'armando', 'armando ortiz', 'maddy/lucy',
+                if json.loads(line[1]['responses'])['Q1'].lower() in ['kirsten','allison','allison\nallison','marisol','marisiol', 'maddy','campbell', 'campbell field', 'kirsten\nkirsten', 'emily', 'bryan', 'armando', 'armando ortiz', 'maddy/lucy',
                                                                       'paxton', 'lucy']:
                     delete = False
                 else:
@@ -376,7 +376,7 @@ def loadEL(dbpath=None, recpath=None, remove_subs=None, wordpool=None, groupby=N
 
     # add custom filters
     if filters:
-        filter_func = [adaptive_filter, experimenter_filter, experiments_filter] + filters
+        filter_func = [adaptive_filter, experimeter_filter, experiments_filter] + filters
     else:
         filter_func = [adaptive_filter, experimenter_filter, experiments_filter]
 


### PR DESCRIPTION
Updates and fixes:

- in `init.py`:
    - added `loadEL()` function to imports

- in `load.py`:
    - changes to load metadata from saved eggs and friedeggs
    - fixed issue with metadata being lost when `update=True`
    - in `loadEL()`:
        - updated `experimenter_filter()` to catch various mistakes and typos. Also added new experimenters' names
        - updated builtin `open()` function `mode` arg to Python 3
        - added feature mapping from stim data to recall dataframes
        - added conversion of bytes and unicode features to Python 3 strings (necessary to match pres/rec data for feature mapping and analyses)

- in `egg.py`:
    - added metadata to `save()` method for both `Egg` and `FriedEgg`

- in `recmat.py`:
    - fixes to `_recmat()` (@andrewheusser 's code)